### PR TITLE
fix: 포맷팅 충돌 제거

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,8 +4,9 @@
   "singleQuote": true,
   "jsxSingleQuote": true,
   "printWidth": 100,
-	"bracketSpacing": true,
-	"arrowParens": "always",
-	"proseWrap": "preserve",
-	"trailingComma": "all"
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "proseWrap": "preserve",
+  "trailingComma": "all",
+  "endOfLine": "lf"
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,15 +1,15 @@
-import { FlatCompat } from '@eslint/eslintrc';
-import { fileURLToPath } from 'url';
 import { dirname } from 'path';
+import { fileURLToPath } from 'url';
 
+import { FlatCompat } from '@eslint/eslintrc';
 import pluginJs from '@eslint/js';
-import pluginReact from 'eslint-plugin-react';
-import pluginReactHooks from 'eslint-plugin-react-hooks';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import configPrettier from 'eslint-config-prettier';
 import pluginImport from 'eslint-plugin-import';
 import pluginPrettier from 'eslint-plugin-prettier';
-import configPrettier from 'eslint-config-prettier';
-import tsParser from '@typescript-eslint/parser';
-import tsPlugin from '@typescript-eslint/eslint-plugin';
+import pluginReact from 'eslint-plugin-react';
+import pluginReactHooks from 'eslint-plugin-react-hooks';
 import globals from 'globals';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -19,7 +19,7 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
-export default [
+const eslintConfig = [
   // 기존 Next.js + React + 기본 ESLint 설정 (FlatCompat로 로드)
   ...compat.extends('next/core-web-vitals'),
 
@@ -40,10 +40,13 @@ export default [
     },
     rules: {
       'no-unused-vars': 'off',
-      '@typescript-eslint/no-unused-vars': ['error', {
-        argsIgnorePattern: '^_',
-        varsIgnorePattern: '^_',
-      }],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
     },
   },
 
@@ -78,7 +81,7 @@ export default [
       'func-names': ['error', 'as-needed'],
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
-      'no-unused-vars': ['error', { args: 'none', ignoreRestSiblings: true }]
+      'no-unused-vars': ['error', { args: 'none', ignoreRestSiblings: true }],
     },
   },
 
@@ -131,3 +134,5 @@ export default [
     },
   },
 ];
+
+export default eslintConfig;


### PR DESCRIPTION
- .prettierrc에 LF(endOfLine) 강제 설정 추가하고,
- eslint.config.js에서 import 순서·그룹 빈줄 정리 및 익명 default export 제거

# 📦 Pull Request

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 💬 공유사항 to 리뷰어

<!--
이 PR에서 집중적으로 리뷰 받고 싶은 부분이나
논의가 필요한 사항을 작성해주세요.
예시: 함수명, 컴포넌트 구조, 성능 최적화 아이디어 등
-->

## 🗂️ 관련 이슈

<!--
- Fixes #123    (머지 시 자동 닫기)
- Refs #124     (참조만)
-->

## 📸 스크린샷

<!-- UI/UX 변경 시 필수로 첨부 -->

## ✅ 체크리스트

- [ ] 빌드 및 테스트 통과
- [ ] ESLint/Prettier 검사 통과
