### PR TITLE
Feature/slider

### DIFF
--- a/src/components/common/slider/DualSlider.tsx
+++ b/src/components/common/slider/DualSlider.tsx
@@ -1,0 +1,37 @@
+import { DualSlider as BaseDualSlider } from '@/components/ui/dual-slider';
+import { cn } from '@/lib/utils';
+
+interface DualSliderProps {
+  value: [number, number];
+  onChange: (value: [number, number]) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  disabled?: boolean;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export default function DualSlider({
+  value,
+  onChange,
+  min = 0,
+  max = 10000,
+  step = 1000,
+  disabled = false,
+  className,
+  ariaLabel = '가격 범위 슬라이더',
+}: DualSliderProps) {
+  return (
+    <BaseDualSlider
+      aria-label={ariaLabel}
+      min={min}
+      max={max}
+      step={step}
+      disabled={disabled}
+      value={value}
+      onValueChange={(val) => onChange([val[0], val[1]])}
+      className={cn('w-full h-7 pt-5', className)}
+    />
+  );
+}

--- a/src/components/common/slider/FlavorSlider.tsx
+++ b/src/components/common/slider/FlavorSlider.tsx
@@ -1,0 +1,71 @@
+import { Slider } from '@/components/ui/slider';
+import { cn } from '@/lib/utils';
+
+import { Badge } from '../../ui/badge';
+
+interface FlavorSliderProps {
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  disabled?: boolean;
+  labelLeft: string;
+  labelRight: string;
+  badgeLabel?: string;
+  className?: string;
+  ariaLabel?: string;
+  ariaLabelledby?: string;
+}
+
+/**
+ * FlavorSlider
+ * - 좌우에 라벨이 붙은 단일 슬라이더
+ * - 맛 성향을 시각적으로 표현할 때 사용
+ */
+export default function FlavorSlider({
+  value,
+  onChange,
+  min = 0,
+  max = 100,
+  step = 1,
+  disabled = false,
+  labelLeft,
+  labelRight,
+  badgeLabel,
+  className,
+  ariaLabel = 'Flavor Slider',
+  ariaLabelledby = 'flavor-slider-label',
+}: FlavorSliderProps) {
+  return (
+    <div className='w-full flex items-center gap-4'>
+      {badgeLabel && (
+        <Badge variant='taste' className='ml-1' id={ariaLabelledby}>
+          {badgeLabel}
+        </Badge>
+      )}
+      <div className='flex items-center justify-between gap-2 flex-1'>
+        {/* 왼쪽 라벨 */}
+        <span className='whitespace-nowrap text-gray-800 custom-text-md-medium  md:custom-text-lg-medium'>
+          {labelLeft}
+        </span>
+        {/* 슬라이더 */}
+        <Slider
+          aria-label={ariaLabel}
+          min={min}
+          max={max}
+          step={step}
+          disabled={disabled}
+          value={[value]}
+          onValueChange={(val) => onChange(val[0])}
+          className={cn('flex-1 h-2', className)}
+        />
+
+        {/* 오른쪽 라벨 */}
+        <span className='whitespace-nowrap text-gray-800 custom-text-md-medium  md:custom-text-lg-medium'>
+          {labelRight}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/dual-slider.tsx
+++ b/src/components/ui/dual-slider.tsx
@@ -3,6 +3,19 @@ import * as React from 'react';
 import * as SliderPrimitive from '@radix-ui/react-slider';
 
 import { cn } from '@/lib/utils';
+const formatCurrency = (value: number) => `₩ ${value.toLocaleString()}`;
+
+const thumbClass = cn(
+  'relative flex flex-col items-center justify-center',
+  'h-5 w-5 rounded-full border border-gray-300 bg-white shadow',
+  'transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+  'disabled:pointer-events-none disabled:opacity-50',
+);
+
+const labelClass = cn(
+  'absolute -top-7  min-w-[60px] custom-text-lg-regular text-primary',
+  'text-center whitespace-nowrap',
+);
 
 const DualSlider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
@@ -15,16 +28,16 @@ const DualSlider = React.forwardRef<
     onValueChange={onValueChange}
     {...props}
   >
-    <SliderPrimitive.Track className='relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20'>
-      <SliderPrimitive.Range className='absolute h-full bg-primary' />
+    <SliderPrimitive.Track className='relative h-1.5 w-full grow overflow-hidden rounded-full bg-gray-100'>
+      <SliderPrimitive.Range className='absolute h-full rounded-full bg-primary' />
     </SliderPrimitive.Track>
 
-    <SliderPrimitive.Thumb className='flex flex-col items-center h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50'>
-      <span className='-mt-8'>{value[0]}</span>
+    <SliderPrimitive.Thumb className={thumbClass}>
+      <span className={labelClass}>{formatCurrency(value[0])}</span>
     </SliderPrimitive.Thumb>
 
-    <SliderPrimitive.Thumb className='flex flex-col items-center h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50'>
-      <span className='-mt-8'>{value[1]}</span>
+    <SliderPrimitive.Thumb className={thumbClass}>
+      <span className={labelClass}>{formatCurrency(value[1])}</span>
     </SliderPrimitive.Thumb>
   </SliderPrimitive.Root>
 ));

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -3,6 +3,18 @@ import * as React from 'react';
 import * as SliderPrimitive from '@radix-ui/react-slider';
 
 import { cn } from '@/lib/utils';
+const trackClass = cn(
+  'relative h-1.5 w-full grow overflow-hidden',
+  'rounded-full bg-gray-100 border border-gray-300 ',
+);
+
+const rangeClass = cn('absolute h-full', 'bg-transparent');
+
+const thumbClass = cn(
+  'block h-4 w-4 rounded-full border border-primary/50 bg-primary shadow',
+  'transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+  'disabled:pointer-events-none disabled:opacity-50',
+);
 
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
@@ -13,12 +25,13 @@ const Slider = React.forwardRef<
     className={cn('relative flex w-full touch-none select-none items-center', className)}
     {...props}
   >
-    <SliderPrimitive.Track className='relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20'>
-      <SliderPrimitive.Range className='absolute h-full bg-primary' />
+    <SliderPrimitive.Track className={trackClass}>
+      <SliderPrimitive.Range className={rangeClass} />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className='block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50' />
+    <SliderPrimitive.Thumb className={thumbClass} />
   </SliderPrimitive.Root>
 ));
+
 Slider.displayName = SliderPrimitive.Root.displayName;
 
 export { Slider };


### PR DESCRIPTION
📝 요약 (Summary)
- FlavorSlider 컴포넌트
→ 단일 슬라이더 UI (좌우 라벨 + 배지 지원)
```
📌 Props 설명
value: 현재 선택된 숫자 값 (number)
onChange: 슬라이더 값 변경 시 호출되는 콜백 (value: number)
min?: 최소값 (기본값: 0)
max?: 최대값 (기본값: 100)
step?: 슬라이더 이동 단위 (기본값: 1)
disabled?: 비활성화 여부
labelLeft: 왼쪽 라벨 텍스트
labelRight: 오른쪽 라벨 텍스트
badgeLabel?: 배지에 표시할 텍스트
ariaLabel?: 접근성 레이블 (기본값: "Flavor Slider")
ariaLabelledby?: aria-labelledby 속성 연결용 id
className?: 커스텀 클래스

예시:
<FlavorSlider
  value={price}
  onChange={setPrice}
  min={0}
  max={100}
  step={5}
  labelLeft="진해요"
  labelRight="가벼워요"
  badgeLabel="당도"
/>
```


- DualSlider 컴포넌트
→ 범위 선택용 슬라이더 인터페이스를 props 기반으로 간결하게 구성

```
📌 Props 설명
value: 현재 선택된 범위 값 ([min, max] 형태의 배열)
onChange: 범위 변경 시 호출되는 콜백 (value: [number, number])
min: 선택 가능 최소값
max: 선택 가능 최대값
step: 이동 단위 (선택)

<DualSlider
  value={range}
  onChange={setRange}
  min={0}
  max={100000}
  step={1000}
/>
```

💬 공유사항 to 리뷰어
- shadcn에서 기본으로 제공되는 Slider/DualSlider 컴포넌트에 스타일을 적용했습니다.

- DualSlider 사용 시, 부모 요소에 너비를 충분히 할당해주세요. 값이 max에 가까워질 때 라벨이 바깥으로 벗어날 수 있습니다.

- TypeScript 쪽에서도 props 타입 정의나 제네릭 활용에 대한 조언 환영합니다.

- 특히 props 네이밍, 접근성(aria-label, aria-labelledby) 처리 방식에 대한 피드백 부탁드립니다.

**- 그리고 prop이 너무 많지 않나요..??????????????????????????**

🗂️ 관련 이슈
Fixes #27  
📸 스크린샷

https://github.com/user-attachments/assets/410e2778-d29a-4b55-8e19-373612711c2b


https://github.com/user-attachments/assets/a7b050d9-fefa-44ed-8b7c-83272f7685b0


https://github.com/user-attachments/assets/b4123c14-8ca8-468f-b74d-ea10be6096fc

<img width="485" height="992" alt="image" src="https://github.com/user-attachments/assets/24f1fa6c-1eeb-4104-8a4a-c99ddccb4e3b" />
