### PR TITLE
Refactor: 모달 닫기 버튼 색상 및 공통 폰트 적용

### DIFF
--- a/src/components/common/Modal/BasicModal.tsx
+++ b/src/components/common/Modal/BasicModal.tsx
@@ -45,7 +45,7 @@ const BasicModal = ({
           {showCloseButton && (
             <DialogClose asChild>
               <button className='absolute top-4 right-5' aria-label='Close'>
-                <Close width={24} height={24} />
+                <Close width={24} height={24} className='text-gray-500' />
               </button>
             </DialogClose>
           )}

--- a/src/components/common/Modal/BasicModal.tsx
+++ b/src/components/common/Modal/BasicModal.tsx
@@ -50,7 +50,9 @@ const BasicModal = ({
             </DialogClose>
           )}
           <DialogHeader>
-            <DialogTitle className='text-xl md:text-2xl text-left'>{title}</DialogTitle>
+            <DialogTitle className='custom-text-xl-bold md:custom-text-2xl-bold text-left'>
+              {title}
+            </DialogTitle>
             <DialogDescription className='sr-only'>다이얼로그 내용</DialogDescription>
           </DialogHeader>
 

--- a/src/components/common/Modal/ConfirmModal.tsx
+++ b/src/components/common/Modal/ConfirmModal.tsx
@@ -25,7 +25,7 @@ const ConfirmModal = ({ children, buttons, open, onOpenChange }: ConfirmModalPro
         >
           <DialogHeader>
             {/* 컨텐츠 영역 */}
-            <DialogTitle className='mt-2 flex justify-center text-xl md:text-2xl'>
+            <DialogTitle className='mt-2 flex justify-center text-lg md:text-xl'>
               {children}
             </DialogTitle>
             <DialogDescription className='sr-only'>다이얼로그 내용</DialogDescription>

--- a/src/components/common/Modal/ConfirmModal.tsx
+++ b/src/components/common/Modal/ConfirmModal.tsx
@@ -25,7 +25,7 @@ const ConfirmModal = ({ children, buttons, open, onOpenChange }: ConfirmModalPro
         >
           <DialogHeader>
             {/* 컨텐츠 영역 */}
-            <DialogTitle className='mt-2 flex justify-center text-lg md:text-xl'>
+            <DialogTitle className='mt-2 flex justify-center custom-text-2lg-bold md:custom-text-xl-bold'>
               {children}
             </DialogTitle>
             <DialogDescription className='sr-only'>다이얼로그 내용</DialogDescription>


### PR DESCRIPTION
# 📦 Pull Request

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- SVG 파일 전체적으로 검정이 적용되어, 닫기 아이콘에 클래스 추가하여 색상을 변경하였습니다.
- 모달의 폰트 굵기가 피그마 시안과 달라 커스텀 폰트를 적용하였습니다.


## 💬 공유사항 to 리뷰어

<!--
이 PR에서 집중적으로 리뷰 받고 싶은 부분이나
논의가 필요한 사항을 작성해주세요.
예시: 함수명, 컴포넌트 구조, 성능 최적화 아이디어 등
-->
간단 디자인 수정입니다.
닫기 버튼은 `showCloseButton` 속성을 false로 주면 안나옵니다.

## 🗂️ 관련 이슈

<!--
- Fixes #123    (머지 시 자동 닫기)
- Refs #124     (참조만)
-->

## 📸 스크린샷

<!-- UI/UX 변경 시 필수로 첨부 -->
<img width="586" height="297" alt="image" src="https://github.com/user-attachments/assets/6ca543b1-28ae-4393-be71-969d4b7c48d6" />


## ✅ 체크리스트

- [ ] 빌드 및 테스트 통과
- [ ] ESLint/Prettier 검사 통과
