### PR TITLE
refactor: 인풋 에러메세지 앱솔루트+오토컴플리트 박스쉐도우 초기화

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-NEXT_PUBLIC_BASE_URL=https://winereview-api.vercel.app/
-NEXT_PUBLIC_TEAM=16-4
-NEXT_PUBLIC_KAKAO_APP_KEY=7b5c127406934830bcf7710ee83e9094
-NEXT_PUBLIC_KAKAO_REDIRECT_URI=http://localhost:3000/oauth/signup/kakao

--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+NEXT_PUBLIC_BASE_URL=https://winereview-api.vercel.app/
+NEXT_PUBLIC_TEAM=16-4
+NEXT_PUBLIC_KAKAO_APP_KEY=7b5c127406934830bcf7710ee83e9094
+NEXT_PUBLIC_KAKAO_REDIRECT_URI=http://localhost:3000/oauth/signup/kakao

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env*
 
 # vercel
 .vercel

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -43,7 +43,13 @@ const Input = forwardRef<HTMLInputElement, Props>(
           )}
           {...rest}
         />
-        <div role='alert' className='text-red-500 mt-[4px]'>
+        <div
+          role='alert'
+          className={cn('text-red-500 mt-[4px] absolute left-0', {
+            'top-12': variant !== 'search',
+            'top-10': variant === 'search',
+          })}
+        >
           {errorMessage}
         </div>
       </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -24,6 +24,11 @@
 }
 
 @layer utilities {
+  input:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0px 1000px white inset;
+    box-shadow: 0 0 0px 1000px white inset;
+  }
+
   /* Text-3xl */
   .custom-text-3xl-bold {
     font-size: 32px;


### PR DESCRIPTION
# 📦 Pull Request

## 📝 요약(Summary)

1.인풋 하단의 에러메세지가 공간을 차지하지 않게 앱솔루트로 띄웠습니다.
2. 자동완성 시 박스쉐도우?가 적용되는 브라우저 기본동작을 흰색으로 바꿨습니다.(global.css @ layer utilities에 추가)

## 💬 공유사항 to 리뷰어



## 🗂️ 관련 이슈

<!--
- Fixes #123    (머지 시 자동 닫기)
- Refs #124     (참조만)
-->

## 📸 스크린샷
<img width="900" height="614" alt="image" src="https://github.com/user-attachments/assets/e972213d-b28d-4c46-b290-b633a53b4272" />


## ✅ 체크리스트

- [x] 빌드 및 테스트 통과
- [x] ESLint/Prettier 검사 통과
