### PR TITLE
refactor/gnb  :  GNB상단 및 좌우측 백드랍 블러 주기

### DIFF
--- a/src/components/common/Gnb.tsx
+++ b/src/components/common/Gnb.tsx
@@ -10,13 +10,15 @@ import UserDefaultImg from './UserDefaultImg';
 
 function Gnb() {
   return (
-    //inset-x-0 -> x축:left,right둘 다 0
-    <header className='z-50 fixed top-0 inset-x-0 mx-auto px-[16px] md:px-[20px] xl:px-0 max-w-[1140px]  min-w-[343px]'>
-      <nav className='flex justify-between items-center bg-black  w-full h-[50px] md:h-[70px] rounded-[12px] md:rounded-[16px] mt-[16px] md:mt-[24px] px-[20px] md:px-[60px]'>
-        <Logo />
-        <AuthMenu />
-      </nav>
-    </header>
+    <div className='z-50 fixed top-0 inset-x-0 bg-white/70 backdrop-blur-md'>
+      {/*  ㄴ백드롭 필터 적용*/}
+      <header className='mx-auto px-[16px] md:px-[20px] xl:px-0 max-w-[1140px]  min-w-[343px]'>
+        <nav className='flex justify-between items-center bg-black  w-full h-[50px] md:h-[70px] rounded-[12px] md:rounded-[16px] mt-[16px] md:mt-[24px] px-[20px] md:px-[60px]'>
+          <Logo />
+          <AuthMenu />
+        </nav>
+      </header>
+    </div>
   );
 }
 


### PR DESCRIPTION
# 📦 Pull Request

## 📝 요약(Summary)

GNB상단 및 좌우측 백드랍 블러 줬습니다.
지금 gnb너비보다 컨텐츠가 더 큰 게 없어서 좌우측까지 백드랍 적용시킨 채로 뒀습니다.


## 💬 공유사항 to 리뷰어

<!--
이 PR에서 집중적으로 리뷰 받고 싶은 부분이나
논의가 필요한 사항을 작성해주세요.
예시: 함수명, 컴포넌트 구조, 성능 최적화 아이디어 등
-->

## 🗂️ 관련 이슈

<!--
- Fixes #123    (머지 시 자동 닫기)
- Refs #124     (참조만)
-->

## 📸 스크린샷
<img width="1305" height="78" alt="image" src="https://github.com/user-attachments/assets/a92677e1-edbf-4113-b99a-360dd8e6149b" />


## ✅ 체크리스트

- [x] 빌드 및 테스트 통과
- [x] ESLint/Prettier 검사 통과
