### PR TITLE
feat: 로그인 후 유저 전역 데이터 세팅

### DIFF
--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/router';
 import { FormProvider, useForm, type SubmitHandler } from 'react-hook-form';
 import z from 'zod';
 
+import { getUser } from '@/api/user';
 import KakaoIcon from '@/assets/icons/kakao.svg';
 import AuthLayout from '@/components/auth/AuthLayout';
 import AuthLogo from '@/components/auth/AuthLogo';
@@ -17,7 +18,9 @@ import { Button } from '@/components/ui/button';
 import useErrorModal from '@/hooks/useErrorModal';
 import useTokenCheckRedirect from '@/hooks/useTokenCheckRedirect';
 import { emailSchema, passwordSchema } from '@/lib/form/schemas';
+import { useUserStore } from '@/stores/userStore';
 import { LoginRequest, LoginResponse } from '@/types/AuthTypes';
+import { GetUserResponse } from '@/types/UserTypes';
 
 import { loginUser } from '../../api/auth';
 
@@ -29,6 +32,7 @@ const LoginSchema = z.object({
 type LoginData = z.infer<typeof LoginSchema>;
 
 const SignIn = () => {
+  const { setUser } = useUserStore();
   const { open, setOpen, handleError, errorMessage } = useErrorModal();
   const { isLoading } = useTokenCheckRedirect();
   const router = useRouter();
@@ -48,7 +52,7 @@ const SignIn = () => {
   const loginMutation = useMutation<LoginResponse, AxiosError, LoginRequest>({
     mutationFn: loginUser,
     onSuccess: () => {
-      router.push('/');
+      userMutation.mutate();
     },
     onError: (error) => {
       if (error.response?.status === 400) {
@@ -58,6 +62,18 @@ const SignIn = () => {
         // API 에러를 모달로 출력
         handleError(error.response?.data as Error);
       }
+    },
+  });
+
+  const userMutation = useMutation<GetUserResponse, AxiosError>({
+    mutationFn: getUser,
+    onSuccess: (data) => {
+      setUser(data);
+      router.push('/');
+    },
+    onError: (error) => {
+      // API 에러를 모달로 출력
+      handleError(error.response?.data as Error);
     },
   });
 

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -17,8 +17,8 @@ import ErrorModal from '@/components/common/Modal/ErrorModal';
 import { Button } from '@/components/ui/button';
 import useErrorModal from '@/hooks/useErrorModal';
 import useTokenCheckRedirect from '@/hooks/useTokenCheckRedirect';
+import { useUser } from '@/hooks/useUser';
 import { emailSchema, passwordSchema } from '@/lib/form/schemas';
-import { useUserStore } from '@/stores/userStore';
 import { LoginRequest, LoginResponse } from '@/types/AuthTypes';
 import { GetUserResponse } from '@/types/UserTypes';
 
@@ -32,7 +32,7 @@ const LoginSchema = z.object({
 type LoginData = z.infer<typeof LoginSchema>;
 
 const SignIn = () => {
-  const { setUser } = useUserStore();
+  const { setUser } = useUser();
   const { open, setOpen, handleError, errorMessage } = useErrorModal();
   const { isLoading } = useTokenCheckRedirect();
   const router = useRouter();

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -17,13 +17,13 @@ import ErrorModal from '@/components/common/Modal/ErrorModal';
 import { Button } from '@/components/ui/button';
 import useErrorModal from '@/hooks/useErrorModal';
 import useTokenCheckRedirect from '@/hooks/useTokenCheckRedirect';
+import { useUser } from '@/hooks/useUser';
 import {
   emailSchema,
   nicknameSchema,
   passwordSchema,
   passwordConfirmationSchema,
 } from '@/lib/form/schemas';
-import { useUserStore } from '@/stores/userStore';
 import { LoginRequest, LoginResponse, SignupRequest, SignupResponse } from '@/types/AuthTypes';
 import { GetUserResponse } from '@/types/UserTypes';
 
@@ -42,7 +42,7 @@ const SignupSchema = z
 type SignupData = z.infer<typeof SignupSchema>;
 
 const Signup = () => {
-  const { setUser } = useUserStore();
+  const { setUser } = useUser();
   const { open, setOpen, handleError, errorMessage } = useErrorModal();
   const { isLoading } = useTokenCheckRedirect();
   const router = useRouter();

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -9,6 +9,7 @@ import { FormProvider, useForm, type SubmitHandler } from 'react-hook-form';
 import z from 'zod';
 
 import { createUser, loginUser } from '@/api/auth';
+import { getUser } from '@/api/user';
 import AuthLayout from '@/components/auth/AuthLayout';
 import AuthLogo from '@/components/auth/AuthLogo';
 import FormInput from '@/components/common/FormInput';
@@ -22,7 +23,9 @@ import {
   passwordSchema,
   passwordConfirmationSchema,
 } from '@/lib/form/schemas';
+import { useUserStore } from '@/stores/userStore';
 import { LoginRequest, LoginResponse, SignupRequest, SignupResponse } from '@/types/AuthTypes';
+import { GetUserResponse } from '@/types/UserTypes';
 
 const SignupSchema = z
   .object({
@@ -39,6 +42,7 @@ const SignupSchema = z
 type SignupData = z.infer<typeof SignupSchema>;
 
 const Signup = () => {
+  const { setUser } = useUserStore();
   const { open, setOpen, handleError, errorMessage } = useErrorModal();
   const { isLoading } = useTokenCheckRedirect();
   const router = useRouter();
@@ -77,6 +81,18 @@ const Signup = () => {
   const loginMutation = useMutation<LoginResponse, AxiosError, LoginRequest>({
     mutationFn: loginUser,
     onSuccess: () => {
+      userMutation.mutate();
+    },
+    onError: (error) => {
+      // API 에러를 모달로 출력
+      handleError(error.response?.data as Error);
+    },
+  });
+
+  const userMutation = useMutation<GetUserResponse, AxiosError>({
+    mutationFn: getUser,
+    onSuccess: (data) => {
+      setUser(data);
       router.push('/');
     },
     onError: (error) => {


### PR DESCRIPTION
# 📦 Pull Request

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 로그인/회원가입 화면에서 로그인 API 호출 후, useUserStore의 `setUser`을 사용하여 `전역 데이터를 저장`하는 부분을 추가

## 💬 공유사항 to 리뷰어

<!--
이 PR에서 집중적으로 리뷰 받고 싶은 부분이나
논의가 필요한 사항을 작성해주세요.
예시: 함수명, 컴포넌트 구조, 성능 최적화 아이디어 등
-->
- 유진님이 만드신 전역 스토어를 연결하는 부분만 추가되었습니다

## 🗂️ 관련 이슈

<!--
- Fixes #123    (머지 시 자동 닫기)
- Refs #124     (참조만)
-->

## 📸 스크린샷

<!-- UI/UX 변경 시 필수로 첨부 -->

## ✅ 체크리스트

- [ ] 빌드 및 테스트 통과
- [ ] ESLint/Prettier 검사 통과
