### PR TITLE
Feature/ 파일 이름 정규화 유틸 함수 추가 및 유저 프로필 관련 토스트 연결

### DIFF
--- a/src/components/my-profile/Profile.tsx
+++ b/src/components/my-profile/Profile.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { useForm, type SubmitHandler } from 'react-hook-form';
+import { toast } from 'sonner';
 
 import { uploadImage, updateProfile } from '@/api/user';
 import Input from '@/components/common/Input';
@@ -79,6 +80,13 @@ export default function Profile() {
   /** 닉네임 또는 이미지가 변경되었는지 여부 */
   const isChanged = isNicknameChanged || isImageChanged;
 
+  /** 에러 메세지 toast */
+  const onInvalid = (errors: Record<string, any>) => {
+    const message = errors.nickname?.message;
+    if (message) {
+      toast.warning('', { description: message });
+    }
+  };
   /**
    * 프로필 수정 form 제출 핸들러
    *
@@ -114,8 +122,14 @@ export default function Profile() {
       // form 초기화 및 파일 제거
       reset({ nickname: updatedUser.nickname });
       setSelectedFile(null);
+
+      toast.success('', {
+        description: '프로필이 성공적으로 수정되었습니다.',
+      });
     } catch (e) {
-      console.error('프로필 수정 오류:', e);
+      toast.error('', {
+        description: '프로필 수정 중 오류가 발생했습니다.',
+      });
     }
   };
 
@@ -134,7 +148,7 @@ export default function Profile() {
 
       {/* 닉네임 변경 폼 */}
       <form
-        onSubmit={handleSubmit(onSubmit)}
+        onSubmit={handleSubmit(onSubmit, onInvalid)}
         className='flex flex-col items-end gap-1.5 md:flex-row xl:flex-col'
       >
         <div className='flex flex-col w-full gap-[10px]'>
@@ -153,13 +167,10 @@ export default function Profile() {
               required: '닉네임을 입력해주세요.',
               minLength: { value: 2, message: '최소 2자 이상 입력하세요.' },
               maxLength: { value: 20, message: '최대 20자까지 가능합니다.' },
+              validate: {
+                noSpaces: (value) => !/\s/.test(value) || '닉네임에 공백을 포함할 수 없습니다.',
+              },
             })}
-            onInvalid={(e: React.FormEvent<HTMLInputElement>) =>
-              console.error(
-                '닉네임 유효성 오류:',
-                (e.currentTarget as HTMLInputElement).validationMessage,
-              )
-            }
           />
         </div>
 

--- a/src/components/my-profile/Profile.tsx
+++ b/src/components/my-profile/Profile.tsx
@@ -134,7 +134,7 @@ export default function Profile() {
   };
 
   return (
-    <div className='p-5 flex flex-col gap-5 rounded-xl border bg-white xl:justify-between xl:py-7 xl:h-[530px] shadow-md'>
+    <div className='p-5 flex flex-col gap-5 rounded-xl border bg-white xl:max-w-[280px] xl:justify-between xl:py-7 xl:h-[530px] shadow-md'>
       {/* 프로필 이미지 + 현재 닉네임 */}
       <div className='flex items-center gap-4 xl:flex-col xl:gap-8'>
         <ProfileImageInput

--- a/src/components/my-profile/ProfileImageInput.tsx
+++ b/src/components/my-profile/ProfileImageInput.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 
 import Camera from '@/assets/camera.svg';
 import UserDefaultImg from '@/assets/icons/userDefaultImg.svg';
+import { renameFileIfNeeded } from '@/lib/renameFile';
 
 interface ProfileImageInputProps {
   /** 미리보기 또는 서버에서 받은 프로필 이미지 URL (null이면 기본 이미지 표시) */
@@ -48,7 +49,8 @@ export function ProfileImageInput({ imageUrl, onFileSelect }: ProfileImageInputP
         return;
       }
 
-      onFileSelect?.(file);
+      const renamedFile = renameFileIfNeeded(file);
+      onFileSelect?.(renamedFile);
     }
   };
 

--- a/src/lib/renameFile.ts
+++ b/src/lib/renameFile.ts
@@ -1,0 +1,43 @@
+/**
+ * 파일 이름을 안전하고 일관된 형식으로 변환합니다.
+ * - 한글, 공백, 특수문자 제거
+ * - 확장자 유지
+ * - 중복 방지를 위해 옵션에 따라 타임스탬프 추가
+ * - 확장자가 없는 경우도 안전하게 처리
+ *
+ * @param originalName 원본 파일 이름
+ * @param useTimestamp 중복 방지를 위해 타임스탬프 추가 여부 (기본값: true)
+ * @returns 변환된 파일 이름
+ */
+export function sanitizeFileName(originalName: string, useTimestamp: boolean = true): string {
+  const extension = originalName.includes('.')
+    ? originalName.substring(originalName.lastIndexOf('.'))
+    : '';
+
+  const baseName = originalName.includes('.')
+    ? originalName.substring(0, originalName.lastIndexOf('.'))
+    : originalName;
+
+  const cleanedBase = baseName
+    .replace(/[^\w\d_-]/g, '') // 특수문자, 한글, 공백 제거
+    .toLowerCase()
+    .slice(0, 50); // 너무 긴 파일명 방지
+
+  const timestamp = Date.now();
+
+  return `${cleanedBase || 'file'}${useTimestamp ? `_${timestamp}` : ''}${extension}`;
+}
+
+/**
+ * File 객체의 이름이 안전하지 않다면, 조건부로 새 이름을 생성하여 새 File 객체 반환
+ *
+ * @param file 원본 File 객체
+ * @returns 이름이 변경된 새 File 객체 (필요 시)
+ */
+export function renameFileIfNeeded(file: File): File {
+  const safeNameWithoutTimestamp = sanitizeFileName(file.name, false);
+  if (file.name === safeNameWithoutTimestamp) return file;
+
+  const newName = sanitizeFileName(file.name, true);
+  return new File([file], newName, { type: file.type });
+}


### PR DESCRIPTION
# 📦 Pull Request

## 📝 요약(Summary)
### 파일명에 한글이 들어가면 이미지가 깨지는 오류가 있어, 파일명 정규화 유틸 함수를 추가하였습니다. 공용으로 사용하시면 됩니다.
 - 사용 목적
    - 사용자 업로드 파일의 이름을 안전하고 일관된 형식으로 정제
    - 서버 저장 시 발생할 수 있는 충돌, 인코딩 문제, 특수문자 문제 방지
    - 파일 이름 비교를 통한 불필요한 File 생성 최소화
    
- `sanitizeFileName(originalName, useTimestamp)` 유틸 함수 추가
    - 특수문자, 공백, 한글 제거
    - 소문자 변환 및 길이 제한 (50자)
    - 확장자 유지
    - 중복 방지를 위한 타임스탬프 옵션 지원

- `renameFileIfNeeded(file)` 유틸 함수 추가
    - 파일 이름이 정제된 이름과 다를 경우에만 새 File 객체 생성
    - 동일한 경우 기존 File 객체 그대로 사용 (리소스 절약)
  
- 사용법
    -  ```
        const file = e.target.files?.[0];
        const safeFile = renameFileIfNeeded(file); <- 파일 선택 시 작동하는 콜백 함수에 위치
        uploadImage(safeFile);
        ```
---
### 추가 수정
- 닉네임 인풋에 공백이 들어가면 제출 못하고 경고 toast 띄우게 수정
- form 제출 시 성공, 에러 토스트 연결 , 인풋 유효성 toast 연결
- Profile 컴포넌트에 max-w 추가 

###

## 💬 공유사항 to 리뷰어

<!--
이 PR에서 집중적으로 리뷰 받고 싶은 부분이나
논의가 필요한 사항을 작성해주세요.
예시: 함수명, 컴포넌트 구조, 성능 최적화 아이디어 등
-->

## 🗂️ 관련 이슈


## 📸 스크린샷

테스트 
<img width="395" height="304" alt="스크린샷 2025-07-31 212507" src="https://github.com/user-attachments/assets/b687ae73-bb63-46f2-a0dd-20a8a460ea27" />


## ✅ 체크리스트

- [ ] 빌드 및 테스트 통과
- [ ] ESLint/Prettier 검사 통과
