### PR TITLE
Feature/auth guard myprofile

### DIFF
--- a/src/components/common/Modal/ErrorModal.tsx
+++ b/src/components/common/Modal/ErrorModal.tsx
@@ -12,6 +12,7 @@ interface ErrorModalProps {
   showCloseButton?: boolean;
   children?: React.ReactNode;
   className?: string;
+  confirmText?: string;
 }
 
 /* 기존에 errorMessage를 props로 받았는데,
@@ -24,6 +25,7 @@ const ErrorModal = ({
   showCloseButton = false,
   children,
   className,
+  confirmText,
 }: ErrorModalProps) => {
   return (
     <Modal
@@ -48,7 +50,7 @@ const ErrorModal = ({
             onConfirm?.();
           }}
         >
-          확인
+          {confirmText ?? '확인'}
         </Button>
       </Modal.Footer>
     </Modal>

--- a/src/hooks/useInitUser.tsx
+++ b/src/hooks/useInitUser.tsx
@@ -7,18 +7,23 @@ import { useUserStore } from '@/stores/userStore';
  * 앱 진입 시 유저 정보를 패치하고 Zustand에 저장하는 훅 */
 export const useInitUser = () => {
   const setUser = useUserStore((state) => state.setUser);
+  const clearUser = useUserStore((state) => state.clearUser);
+  const setIsUserLoading = useUserStore((state) => state.setIsUserLoading);
 
-  /* 처음에만 실행 */
   useEffect(() => {
     const fetchUser = async () => {
+      setIsUserLoading(true); // 유저 정보 불러오기 시작
+
       try {
-        const user = await getUser();
-        setUser(user);
+        const user = await getUser(); //  API 호출
+        setUser(user); // 로그인 상태로 전역 상태 설정
       } catch (error) {
-        // 로그인 안 돼있는 경우 무시
+        clearUser(); // 실패 시 로그아웃 상태로 초기화
+      } finally {
+        setIsUserLoading(false); // 로딩 끝
       }
     };
 
     fetchUser();
-  }, [setUser]);
+  }, [setUser, clearUser, setIsUserLoading]);
 };

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -5,8 +5,9 @@ import { useUserStore } from '@/stores/userStore';
 export const useUser = () => {
   const user = useUserStore((state) => state.user);
   const isLoggedIn = useUserStore((state) => state.isLoggedIn);
+  const isUserLoading = useUserStore((state) => state.isUserLoading);
   const setUser = useUserStore((state) => state.setUser);
   const clearUser = useUserStore((state) => state.clearUser);
 
-  return { user, isLoggedIn, setUser, clearUser };
+  return { user, isLoggedIn, isUserLoading, setUser, clearUser };
 };

--- a/src/pages/my-profile/index.tsx
+++ b/src/pages/my-profile/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import { useRouter } from 'next/router';
 
+import { LoadingOverlay } from '@/components/common/LoadingOverlay';
 import ErrorModal from '@/components/common/Modal/ErrorModal';
 import Profile from '@/components/my-profile/Profile';
 import { ReviewList } from '@/components/my-profile/ReviewList';
@@ -20,33 +21,28 @@ import { useUser } from '@/hooks/useUser';
  */
 export default function MyProfile() {
   const router = useRouter();
-  const { isLoggedIn } = useUser();
+  const { isLoggedIn, isUserLoading } = useUser();
   const [showModal, setShowModal] = useState(false);
 
+  const [tab, setTab] = useState<'reviews' | 'wines'>('reviews');
+  const [reviewsCount, setReviewsCount] = useState(0);
+  const [winesCount, setWinesCount] = useState(0);
+
   useEffect(() => {
-    if (!isLoggedIn) {
-      setShowModal(true); // 비로그인 시 모달 표시
+    if (!isUserLoading && !isLoggedIn) {
+      setShowModal(true);
     }
-  }, [isLoggedIn]);
+  }, [isLoggedIn, isUserLoading]);
 
   const handleRedirect = () => {
     router.push('/signin'); // 로그인 페이지로 이동
   };
-  /**
-   * 현재 선택된 탭 상태
-   * - 'reviews': 내가 쓴 리뷰
-   * - 'wines': 내가 등록한 와인
-   */
-  const [tab, setTab] = useState<'reviews' | 'wines'>('reviews');
-
-  /** 리뷰 총 개수 (리뷰 탭에서 ReviewList가 설정함) */
-  const [reviewsCount, setReviewsCount] = useState(0);
-
-  /** 와인 총 개수 (와인 탭에서 WineList가 설정함) */
-  const [winesCount, setWinesCount] = useState(0);
 
   return (
     <div>
+      {/* 로딩 중일 때 전체 오버레이 */}
+      {isUserLoading && <LoadingOverlay />}
+
       <ErrorModal
         open={showModal}
         onOpenChange={() => {}}

--- a/src/pages/my-profile/index.tsx
+++ b/src/pages/my-profile/index.tsx
@@ -1,9 +1,13 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
+import { useRouter } from 'next/router';
+
+import ErrorModal from '@/components/common/Modal/ErrorModal';
 import Profile from '@/components/my-profile/Profile';
 import { ReviewList } from '@/components/my-profile/ReviewList';
 import { TabNav } from '@/components/my-profile/Tab';
 import { WineList } from '@/components/my-profile/WineList';
+import { useUser } from '@/hooks/useUser';
 
 /**
  * MyProfile
@@ -15,6 +19,19 @@ import { WineList } from '@/components/my-profile/WineList';
  * - 각 리스트의 총 개수를 상위에서 관리
  */
 export default function MyProfile() {
+  const router = useRouter();
+  const { isLoggedIn } = useUser();
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      setShowModal(true); // 비로그인 시 모달 표시
+    }
+  }, [isLoggedIn]);
+
+  const handleRedirect = () => {
+    router.push('/signin'); // 로그인 페이지로 이동
+  };
   /**
    * 현재 선택된 탭 상태
    * - 'reviews': 내가 쓴 리뷰
@@ -30,28 +47,38 @@ export default function MyProfile() {
 
   return (
     <div>
-      <main className='max-w-6xl mx-auto p-4 gap-6 flex flex-col xl:flex-row'>
-        {/* 프로필 섹션 */}
-        <Profile />
+      <ErrorModal
+        open={showModal}
+        onOpenChange={() => {}}
+        onConfirm={handleRedirect}
+        confirmText='로그인 하러 가기'
+      >
+        마이페이지는 로그인 후 이용할 수 있어요
+      </ErrorModal>
+      {isLoggedIn && (
+        <main className='max-w-6xl mx-auto p-4 gap-6 flex flex-col xl:flex-row'>
+          {/* 프로필 섹션 */}
+          <Profile />
 
-        {/* 탭 + 리스트 */}
-        <div className='flex flex-col flex-1'>
-          {/* 탭 네비게이션: 현재 탭, 탭 전환 함수, 각각의 개수 전달 */}
-          <TabNav
-            current={tab}
-            onChange={setTab}
-            reviewsCount={reviewsCount}
-            winesCount={winesCount}
-          />
+          {/* 탭 + 리스트 */}
+          <div className='flex flex-col flex-1'>
+            {/* 탭 네비게이션: 현재 탭, 탭 전환 함수, 각각의 개수 전달 */}
+            <TabNav
+              current={tab}
+              onChange={setTab}
+              reviewsCount={reviewsCount}
+              winesCount={winesCount}
+            />
 
-          {/* 탭 상태에 따라 리스트 컴포넌트 조건부 렌더링 */}
-          {tab === 'reviews' ? (
-            <ReviewList setTotalCount={setReviewsCount} />
-          ) : (
-            <WineList setTotalCount={setWinesCount} />
-          )}
-        </div>
-      </main>
+            {/* 탭 상태에 따라 리스트 컴포넌트 조건부 렌더링 */}
+            {tab === 'reviews' ? (
+              <ReviewList setTotalCount={setReviewsCount} />
+            ) : (
+              <WineList setTotalCount={setWinesCount} />
+            )}
+          </div>
+        </main>
+      )}
     </div>
   );
 }

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -1,32 +1,42 @@
 import { create } from 'zustand';
 
-/* 유저 정보 타입 */
-interface User {
-  id: number;
-  nickname: string;
-  image: string | null;
-  teamId: string;
-  createdAt: string;
-  updatedAt: string;
-}
+import { GetUserResponse } from '@/types/UserTypes';
 
 /* Zustand 유저 상태 저장소 타입 */
 interface UserStore {
-  user: User | null;
+  user: GetUserResponse | null;
   isLoggedIn: boolean;
+  isUserLoading: boolean;
 
   /* 유저 정보 설정 (로그인 등) */
-  setUser: (user: User) => void;
+  setUser: (user: GetUserResponse) => void;
 
   /* 유저 정보 초기화 (로그아웃 등) */
   clearUser: () => void;
+
+  /* 유저 정보 로딩 상태 변경 */
+  setIsUserLoading: (loading: boolean) => void;
 }
 
 /**
- *  유저 상태 전역 스토어 */
+ * 유저 상태 전역 스토어
+ */
 export const useUserStore = create<UserStore>((set) => ({
   user: null,
   isLoggedIn: false,
-  setUser: (user) => set({ user, isLoggedIn: true }),
-  clearUser: () => set({ user: null, isLoggedIn: false }),
+  isUserLoading: true,
+
+  setUser: (user) =>
+    set({
+      user,
+      isLoggedIn: true,
+    }),
+
+  clearUser: () =>
+    set({
+      user: null,
+      isLoggedIn: false,
+    }),
+
+  setIsUserLoading: (loading) => set({ isUserLoading: loading }),
 }));


### PR DESCRIPTION
# 📦 Pull Request

## 📝 요약(Summary)

- 마이프로필 페이지(MyProfile)에 로그인 가드 로직 적용
  - 비로그인 상태에서 접근 시 ErrorModal 표시 후 로그인 페이지로 리다이렉트
  - zustand의 `isUserLoading` 상태를 활용해 사용자 정보 로딩 완료 여부 체크

- 로딩 중일 때 전체 화면에 LoadingOverlay 표시
  - 기존 `return <div>로딩 중...</div>` 방식을 제거하고, UI 깜빡임 방지 처리
  - `isUserLoading && <LoadingOverlay />`로 자연스럽게 처리

## 💬 공유사항 to 리뷰어

- `zustand`에 `isUserLoading` 상태가 있어야 하고, `useInitUser()`에서 이를 정확히 처리해야 정상 작동합니다.
- 로그인 여부가 확실하게 체크된 뒤에 페이지 렌더링됨
- 비로그인 접근 시 UX 흐름이 자연스럽게 전환됨

## 🗂️ 관련 이슈


## 📸 스크린샷

비로그인 상태로 접근
https://github.com/user-attachments/assets/69f4acde-de78-41b9-a362-f0e02401f21c

새로고침
https://github.com/user-attachments/assets/b6e5e71a-826e-4b06-b09d-511b95e14b5d



## ✅ 체크리스트

- [ ] 빌드 및 테스트 통과
- [ ] ESLint/Prettier 검사 통과
