### PR TITLE
Refactor: 로그인/회원가입 API 에러메시지 인풋 밑에 출력되는 부분 수정

### DIFF
--- a/src/hooks/useTokenCheckRedirect.tsx
+++ b/src/hooks/useTokenCheckRedirect.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 
 import { checkToken } from '@/api/auth';
 
-const useTokenCheck = () => {
+const useTokenCheckRedirect = () => {
   const router = useRouter();
 
   const { data: tokenData, isLoading } = useQuery({
@@ -23,4 +23,4 @@ const useTokenCheck = () => {
   return { isLoading, tokenData };
 };
 
-export default useTokenCheck;
+export default useTokenCheckRedirect;

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -54,12 +54,15 @@ const SignIn = () => {
       userMutation.mutate();
     },
     onError: (error) => {
-      if (error.response?.status === 400) {
-        // 로그인 오류인 경우 공통 에러 메시지
-        setError('email', { message: '이메일 혹은 비밀번호를 확인해주세요' });
-      } else {
-        // API 에러를 모달로 출력
-        handleError(error.response?.data as Error);
+      const err = error as AxiosError<{ message?: string }>;
+      const status = err.response?.status;
+
+      switch (status) {
+        case 400:
+          setError('email', { message: '이메일 혹은 비밀번호를 확인해주세요' });
+          break;
+        default:
+          handleError(error.response?.data as Error);
       }
     },
   });

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -44,9 +44,8 @@ const SignIn = () => {
 
   const {
     handleSubmit,
-    clearErrors,
     setError,
-    formState: { errors, isValid },
+    formState: { isValid },
   } = methods;
 
   const loginMutation = useMutation<LoginResponse, AxiosError, LoginRequest>({
@@ -57,7 +56,7 @@ const SignIn = () => {
     onError: (error) => {
       if (error.response?.status === 400) {
         // 로그인 오류인 경우 공통 에러 메시지
-        setError('root', { message: '이메일 혹은 비밀번호를 확인해주세요' });
+        setError('email', { message: '이메일 혹은 비밀번호를 확인해주세요' });
       } else {
         // API 에러를 모달로 출력
         handleError(error.response?.data as Error);
@@ -105,15 +104,7 @@ const SignIn = () => {
             {/* 이메일 */}
             <div className='flex flex-col gap-2.5'>
               <label htmlFor='email'>이메일</label>
-              <FormInput
-                type='email'
-                id='email'
-                name='email'
-                placeholder='user@email.com'
-                onChange={() => {
-                  clearErrors('root');
-                }}
-              />
+              <FormInput type='email' id='email' name='email' placeholder='user@email.com' />
             </div>
             {/* 비밀번호 */}
             <div className='flex flex-col gap-2.5'>
@@ -123,15 +114,9 @@ const SignIn = () => {
                 id='password'
                 name='password'
                 placeholder='영문, 숫자, 특수문자(!@#$%^&*) 제한'
-                onChange={() => {
-                  clearErrors('root');
-                }}
               />
             </div>
           </div>
-
-          {/* 로그인 오류 출력 */}
-          {errors.root && <p className='text-red-500 flex self-start'>{errors.root.message}</p>}
 
           <div className='flex flex-col mb-10 gap-4'>
             <Button


### PR DESCRIPTION
# 📦 Pull Request

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 로그인 오류 시 이메일 인풋 밑에 에러메시지 출력되게 수정 (요구사항에 나와있음)
- 회원가입 시 이메일, 닉네임 중복 오류가 나면 해당 인풋 밑에 에러메시지 표시되게 수정

## 💬 공유사항 to 리뷰어

<!--
이 PR에서 집중적으로 리뷰 받고 싶은 부분이나
논의가 필요한 사항을 작성해주세요.
예시: 함수명, 컴포넌트 구조, 성능 최적화 아이디어 등
-->

## 🗂️ 관련 이슈

<!--
- Fixes #123    (머지 시 자동 닫기)
- Refs #124     (참조만)
-->

## 📸 스크린샷

<!-- UI/UX 변경 시 필수로 첨부 -->
**[로그인 화면 - 이메일 / 비밀번호 오류]**
![로그인 오류](https://github.com/user-attachments/assets/38d2cf95-1afb-4a73-a1df-af1b1500064a)


**[회원가입 화면 - 닉네임 중복 오류]**
![회원가입 - 닉네임 중복 오류](https://github.com/user-attachments/assets/84fc3908-a0d3-46bc-9ffb-558c5ff27502)


**[회원가입 화면 - 이메일 중복 오류]**
![회원가입 - 이메일 중복 오류](https://github.com/user-attachments/assets/2c4718ee-f1c1-4db6-85c0-afcd8b5ccc6c)


## ✅ 체크리스트

- [ ] 빌드 및 테스트 통과
- [ ] ESLint/Prettier 검사 통과
