### PR TITLE
Fix/my profile list - 무한스크롤 시 스크롤 튐 현상 개선 (ReviewList, WineList), 로딩중에 데이터 없음 띄우지 않게 수정 + 챗봇 z-index 낮춤

### DIFF
--- a/src/components/my-profile/ReviewList.tsx
+++ b/src/components/my-profile/ReviewList.tsx
@@ -20,19 +20,22 @@ const PAGE_LIMIT = 10;
 interface ReviewListProps {
   setTotalCount: (count: number) => void;
 }
+
 /**
  * ReviewList 컴포넌트
  *
- * 무한 스크롤을 통해 사용자의 리뷰 목록을 페이징하여 불러옴
- * IntersectionObserver로 스크롤 끝에 도달 시 다음 페이지를 자동으로 로드
- *
+ * - 무한 스크롤로 사용자 리뷰를 페이지 단위로 로드
+ * - IntersectionObserver를 사용해 하단 감지
+ * - fetch 시 스크롤 튐 현상을 방지하기 위한 보정 로직 포함
  */
 export function ReviewList({ setTotalCount }: ReviewListProps) {
   const [editReview, setEditReview] = useState<MyReview | null>(null);
   const [deleteReviewId, setDeleteReviewId] = useState<number | null>(null);
-  const observerRef = useRef<HTMLDivElement | null>(null);
 
-  // useInfiniteQuery 훅으로 리뷰 데이터를 무한 스크롤 형태로 조회
+  const observerRef = useRef<HTMLDivElement | null>(null); // 옵저버 대상 요소
+  const prevScrollY = useRef<number>(0); // 추가됨: fetch 이전 스크롤 위치 기억용
+
+  // 무한 스크롤 쿼리 세팅
   const { data, isError, error, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
     {
       queryKey: ['reviews'],
@@ -41,14 +44,15 @@ export function ReviewList({ setTotalCount }: ReviewListProps) {
       getNextPageParam: (lastPage) => lastPage.nextCursor ?? null,
     },
   );
-  // xhx
+
+  // 전체 리뷰 수 설정
   useEffect(() => {
     if (data?.pages?.[0]?.totalCount != null) {
       setTotalCount(data.pages[0].totalCount);
     }
   }, [data, setTotalCount]);
 
-  // IntersectionObserver 훅 적용으로 스크롤 끝 감지
+  // 👀 IntersectionObserver 감지 로직 연결
   useInfiniteScroll({
     targetRef: observerRef,
     hasNextPage,
@@ -56,14 +60,31 @@ export function ReviewList({ setTotalCount }: ReviewListProps) {
     isFetching: isFetchingNextPage,
   });
 
+  //  fetch 시작 전 현재 스크롤 위치 기억 (스크롤 튐 방지 목적)
+  useEffect(() => {
+    if (isFetchingNextPage) {
+      prevScrollY.current = window.scrollY;
+    }
+  }, [isFetchingNextPage]);
+
+  // fetch 완료 후 이전 스크롤 위치로 복원
+  useEffect(() => {
+    if (!isFetchingNextPage) {
+      requestAnimationFrame(() => {
+        window.scrollTo({ top: prevScrollY.current, behavior: 'instant' });
+      });
+    }
+  }, [data?.pages.length]);
+
   if (isError) throw error;
 
-  // 리뷰 목록 평탄화
+  //  정렬: 최신순 (createdAt 기준 내림차순)
   const reviews: MyReview[] =
     data?.pages
       ?.flatMap((page) => page.list ?? [])
       ?.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()) ?? [];
 
+  //  빈 목록 처리
   if (!data || data.pages[0].list.length === 0) {
     return <MyPageEmpty type='reviews' />;
   }
@@ -75,7 +96,7 @@ export function ReviewList({ setTotalCount }: ReviewListProps) {
           key={review.id}
           rating={
             <Badge variant='star'>
-              <span className='flex items-center  gap-[2px] w-full h-full'>
+              <span className='flex items-center gap-[2px] w-full h-full'>
                 <StarIcon className='w-[14px] h-[13px] pb-[2px]' />
                 {review.rating.toFixed(1)}
               </span>
@@ -106,6 +127,8 @@ export function ReviewList({ setTotalCount }: ReviewListProps) {
           }
         />
       ))}
+
+      {/*  리뷰 수정 모달 */}
       {editReview && (
         <EditReviewModal
           wineName={editReview.wine.name}
@@ -117,6 +140,7 @@ export function ReviewList({ setTotalCount }: ReviewListProps) {
         />
       )}
 
+      {/*  리뷰 삭제 모달 */}
       {deleteReviewId !== null && (
         <DeleteModal
           type='review'
@@ -128,8 +152,8 @@ export function ReviewList({ setTotalCount }: ReviewListProps) {
         />
       )}
 
-      {/* 옵저버 감지 요소 */}
-      <div ref={observerRef} className='w-1 h-1' />
+      {/*  옵저버가 감지할 요소 */}
+      <div ref={observerRef} className='w-full h-4' />
     </div>
   );
 }

--- a/src/components/my-profile/ReviewList.tsx
+++ b/src/components/my-profile/ReviewList.tsx
@@ -85,7 +85,13 @@ export function ReviewList({ setTotalCount }: ReviewListProps) {
       ?.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()) ?? [];
 
   //  빈 목록 처리
-  if (!data || data.pages[0].list.length === 0) {
+  if (!data || !data.pages) {
+    return null; // 아직 로딩 중이면 아무것도 안 보여줌
+  }
+
+  const isEmpty = data.pages[0].list.length === 0;
+
+  if (!isFetchingNextPage && isEmpty) {
     return <MyPageEmpty type='reviews' />;
   }
 

--- a/src/components/my-profile/WineList.tsx
+++ b/src/components/my-profile/WineList.tsx
@@ -81,7 +81,14 @@ export function WineList({ setTotalCount }: WineListProps) {
   const wines: MyWine[] =
     data?.pages?.flatMap((page) => page?.list ?? [])?.sort((a, b) => b.id - a.id) ?? [];
 
-  if (!data || data.pages[0].list.length === 0) {
+  //  빈 목록 처리
+  if (!data || !data.pages) {
+    return null; // 아직 로딩 중이면 아무것도 안 보여줌
+  }
+
+  const isEmpty = data.pages[0].list.length === 0;
+
+  if (!isFetchingNextPage && isEmpty) {
     return <MyPageEmpty type='wines' />;
   }
 

--- a/src/components/my-profile/WineList.tsx
+++ b/src/components/my-profile/WineList.tsx
@@ -16,22 +16,25 @@ import EditWineModal from '../Modal/WineModal/EditWineModal';
 import type { MyWine, MyWinesResponse } from '@/types/MyWinesTypes';
 
 const PAGE_LIMIT = 10;
+
 interface WineListProps {
   setTotalCount: (count: number) => void;
 }
+
 /**
  * WineList 컴포넌트
  *
- * 무한 스크롤을 통해 사용자의 와인 목록을 페이징하여 불러옴
- * IntersectionObserver로 스크롤 끝에 도달 시 추가 페이지를 자동으로 로드
- *
+ * - 무한 스크롤로 사용자 와인 목록 로딩
+ * - fetch 시 스크롤 튐 방지 로직 포함
  */
 export function WineList({ setTotalCount }: WineListProps) {
   const observerRef = useRef<HTMLDivElement | null>(null);
+  const prevScrollY = useRef<number>(0); // 스크롤 위치 저장용 ref
+
   const [editWine, setEditWine] = useState<MyWine | null>(null);
   const [deleteWineId, setDeleteWineId] = useState<number | null>(null);
 
-  //useInfiniteQuery 훅으로 와인 데이터를 무한 스크롤 형태로 조회
+  // 무한 스크롤 쿼리
   const { data, isError, error, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
     {
       queryKey: ['wines'],
@@ -41,13 +44,14 @@ export function WineList({ setTotalCount }: WineListProps) {
     },
   );
 
+  // 총 와인 수 반영
   useEffect(() => {
     if (data?.pages?.[0]?.totalCount != null) {
       setTotalCount(data.pages[0].totalCount);
     }
   }, [data, setTotalCount]);
 
-  // IntersectionObserver 훅 적용으로 스크롤 끝 감지
+  // 옵저버로 무한 스크롤 감지
   useInfiniteScroll({
     targetRef: observerRef,
     hasNextPage: !!hasNextPage,
@@ -55,9 +59,25 @@ export function WineList({ setTotalCount }: WineListProps) {
     isFetching: isFetchingNextPage,
   });
 
+  // fetch 시작 전에 현재 스크롤 위치 저장
+  useEffect(() => {
+    if (isFetchingNextPage) {
+      prevScrollY.current = window.scrollY;
+    }
+  }, [isFetchingNextPage]);
+
+  // fetch 완료 후 이전 스크롤 위치로 복원
+  useEffect(() => {
+    if (!isFetchingNextPage) {
+      requestAnimationFrame(() => {
+        window.scrollTo({ top: prevScrollY.current, behavior: 'instant' });
+      });
+    }
+  }, [data?.pages.length]);
+
   if (isError) throw error;
 
-  // 와인 목록 평탄화
+  // 최신순 (ID 기준 내림차순)
   const wines: MyWine[] =
     data?.pages?.flatMap((page) => page?.list ?? [])?.sort((a, b) => b.id - a.id) ?? [];
 
@@ -109,10 +129,12 @@ export function WineList({ setTotalCount }: WineListProps) {
           </div>
         </ImageCard>
       ))}
+
+      {/* 수정 모달 */}
       {editWine && (
         <EditWineModal
           wine={{
-            wineId: editWine.id, // MyWine → EditWineModal 타입 변환
+            wineId: editWine.id,
             name: editWine.name,
             price: editWine.price,
             region: editWine.region,
@@ -127,6 +149,7 @@ export function WineList({ setTotalCount }: WineListProps) {
         />
       )}
 
+      {/* 삭제 모달 */}
       {deleteWineId !== null && (
         <DeleteModal
           type='wine'
@@ -137,8 +160,9 @@ export function WineList({ setTotalCount }: WineListProps) {
           }}
         />
       )}
-      {/* 옵저버 감지 요소 */}
-      <div ref={observerRef} className='w-1 h-1' />
+
+      {/* IntersectionObserver 감지용 요소 */}
+      <div ref={observerRef} className='w-full h-4' />
     </div>
   );
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -35,6 +35,21 @@ export default function Document() {
           src='https://chatling.ai/js/embed.js'
           strategy='afterInteractive'
         />
+        <Script
+          id='lower-chatling-z'
+          strategy='afterInteractive'
+          dangerouslySetInnerHTML={{
+            __html: `
+      const lowerZ = () => {
+        document.querySelectorAll('iframe[src*="chatling"]').forEach(e => e.style.zIndex = '50');
+        document.querySelectorAll('div[style*="z-index: 2147483647"]').forEach(e => e.style.zIndex = '50');
+      };
+      lowerZ();
+      const obs = new MutationObserver(lowerZ);
+      obs.observe(document.body, { childList: true, subtree: true });
+    `,
+          }}
+        />
       </body>
     </Html>
   );


### PR DESCRIPTION
# 📦 Pull Request

## 📝 요약(Summary)
- 챗봇 z-index 강제로 50 설정 (로딩 오버레이보다 낮게)
- 리스트 로딩 끝나고 데이터 없을 때만 MyPageEmpty 컴포넌트가 보이게 수정

### ReviewList.tsx/ WineList.tsx 무한스크롤 스크롤 튐 현상
- 무한스크롤 구조에서 createdAt 최신순 정렬 시, 데이터 prepend로 인해 스크롤이 튀는 문제 해결
- window.scrollY를 저장 → 데이터 fetch 완료 후 scroll 위치 복원
- 적용 방식
```
const prevScrollY = useRef(0);

useEffect(() => {
  if (isFetchingNextPage) {
    prevScrollY.current = window.scrollY;
  }
}, [isFetchingNextPage]);

useEffect(() => {
  if (!isFetchingNextPage) {
    requestAnimationFrame(() => {
      window.scrollTo({ top: prevScrollY.current, behavior: 'instant' });
    });
  }
}, [data?.pages.length]);
```

## 💬 공유사항 to 리뷰어

<!--
이 PR에서 집중적으로 리뷰 받고 싶은 부분이나
논의가 필요한 사항을 작성해주세요.
예시: 함수명, 컴포넌트 구조, 성능 최적화 아이디어 등
-->

## 🗂️ 관련 이슈

<!--
- Fixes #123    (머지 시 자동 닫기)
- Refs #124     (참조만)
-->

## 📸 스크린샷

<!-- UI/UX 변경 시 필수로 첨부 -->

## ✅ 체크리스트

- [ ] 빌드 및 테스트 통과
- [ ] ESLint/Prettier 검사 통과
